### PR TITLE
Refactoring: Introduce CastleDevice::Context

### DIFF
--- a/lib/castle_devise.rb
+++ b/lib/castle_devise.rb
@@ -33,6 +33,7 @@ module CastleDevise
 end
 
 require_relative "castle_devise/configuration"
+require_relative "castle_devise/context"
 require_relative "castle_devise/patches"
 require_relative "castle_devise/sdk_facade"
 require_relative "castle_devise/controllers/helpers"

--- a/lib/castle_devise/context.rb
+++ b/lib/castle_devise/context.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module CastleDevise
+  # Provides a small layer of abstraction on top of raw Rack::Request and Warden
+  class Context
+    class << self
+      # @param warden [Warden::Proxy]
+      # @param resource [ActiveRecord::Base]
+      # @param scope [Symbol]
+      # @return [CastleDevise::Context]
+      def from_warden(warden, resource, scope)
+        new(
+          rack_request: Rack::Request.new(warden.env),
+          resource: resource,
+          scope: scope
+        )
+      end
+
+      # @param rack_env [Hash]
+      # @return [CastleDevise::Context]
+      def from_rack_env(rack_env)
+        new(rack_request: Rack::Request.new(rack_env))
+      end
+    end
+
+    attr_reader :rack_request, :resource, :scope
+
+    # @param rack_request [Rack::Request]
+    # @param resource [ActiveRecord::Base]
+    # @param scope [Symbol] Warden scope
+    def initialize(rack_request:, resource: nil, scope: nil)
+      @rack_request = rack_request
+      @resource = resource
+      @scope = scope
+    end
+
+    # @return [String, nil] Castle request token, if present in POST params
+    def request_token
+      rack_request.env["rack.request.form_hash"]["castle_request_token"]
+    end
+
+    # @return [String, nil]
+    def castle_id
+      resource&.castle_id
+    end
+
+    # @return [String, nil]
+    def email
+      resource&.email
+    end
+
+    # @return [Hash]
+    def user_traits
+      resource&.castle_traits || {}
+    end
+
+    # @return [Time, nil]
+    def registered_at
+      resource&.created_at
+    end
+
+    # Logs out current resource
+    def logout!
+      warden.logout(scope)
+      throw(:warden, scope: scope, message: :not_found_in_database)
+    end
+
+    private
+
+    # @return [Warden::Proxy]
+    def warden
+      rack_request.env["warden"]
+    end
+  end
+end

--- a/lib/castle_devise/patches/registrations_controller.rb
+++ b/lib/castle_devise/patches/registrations_controller.rb
@@ -12,7 +12,7 @@ module CastleDevise
       def castle_filter
         response = CastleDevise.sdk_facade.filter(
           event: "$registration",
-          rack_request: Rack::Request.new(request.env)
+          context: CastleDevise::Context.from_rack_env(request.env)
         )
 
         case response.dig(:policy, :action)

--- a/lib/castle_devise/sdk_facade.rb
+++ b/lib/castle_devise/sdk_facade.rb
@@ -11,30 +11,29 @@ module CastleDevise
     end
 
     # @param event [String]
-    # @param rack_request [Rack::Request]
-    def filter(event:, rack_request:)
+    # @param context [CastleDevise::Context]
+    def filter(event:, context:)
       castle.filter(
         event: event,
-        request_token: rack_request.env["action_dispatch.request.parameters"]["castle_request_token"],
-        context: Castle::Context::Prepare.call(rack_request)
+        request_token: context.request_token,
+        context: Castle::Context::Prepare.call(context.rack_request)
       )
     end
 
     # @param event [String]
-    # @param resource [ActiveRecord::Base]
-    # @param rack_request [Rack::Request]
-    def risk(event:, resource:, rack_request:)
+    # @param context [CastleDevise::Context]
+    def risk(event:, context:)
       castle.risk(
         event: event,
         status: "$succeeded",
         user: {
-          id: resource.castle_id,
-          email: resource.email,
-          registered_at: resource.created_at.utc.iso8601(3),
-          traits: resource.castle_traits
+          id: context.castle_id,
+          email: context.email,
+          registered_at: context.registered_at.utc.iso8601(3),
+          traits: context.user_traits
         },
-        request_token: rack_request.env["action_dispatch.request.parameters"]["castle_request_token"],
-        context: Castle::Context::Prepare.call(rack_request)
+        request_token: context.request_token,
+        context: Castle::Context::Prepare.call(context.rack_request)
       )
     end
   end

--- a/spec/castle_devise/integration/login_spec.rb
+++ b/spec/castle_devise/integration/login_spec.rb
@@ -45,10 +45,10 @@ RSpec.describe "Logging in", type: :request do
       let(:policy_action) { "allow" }
 
       it "calls the facade with valid arguments" do
-        expect(facade).to have_received(:risk) do |event:, resource:, rack_request:|
+        expect(facade).to have_received(:risk) do |event:, context:|
           expect(event).to eq("$login")
-          expect(resource).to eq(user)
-          expect(rack_request).to be_a(Rack::Request)
+          expect(context).to be_a(CastleDevise::Context)
+          expect(context.resource).to eq(user)
         end
       end
 
@@ -61,10 +61,10 @@ RSpec.describe "Logging in", type: :request do
       let(:policy_action) { "challenge" }
 
       it "calls the facade with valid arguments" do
-        expect(facade).to have_received(:risk) do |event:, resource:, rack_request:|
+        expect(facade).to have_received(:risk) do |event:, context:|
           expect(event).to eq("$login")
-          expect(resource).to eq(user)
-          expect(rack_request).to be_a(Rack::Request)
+          expect(context).to be_a(CastleDevise::Context)
+          expect(context.resource).to eq(user)
         end
       end
 
@@ -76,10 +76,10 @@ RSpec.describe "Logging in", type: :request do
       let(:policy_action) { "deny" }
 
       it "calls the facade with valid arguments" do
-        expect(facade).to have_received(:risk) do |event:, resource:, rack_request:|
+        expect(facade).to have_received(:risk) do |event:, context:|
           expect(event).to eq("$login")
-          expect(resource).to eq(user)
-          expect(rack_request).to be_a(Rack::Request)
+          expect(context).to be_a(CastleDevise::Context)
+          expect(context.resource).to eq(user)
         end
       end
 

--- a/spec/castle_devise/integration/registration_spec.rb
+++ b/spec/castle_devise/integration/registration_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe "Registration attempt", type: :request do
     let(:policy_action) { "allow" }
 
     it "sends requests to Castle" do
-      expect(facade).to have_received(:filter) do |event:, rack_request:|
+      expect(facade).to have_received(:filter) do |event:, context:|
         expect(event).to eq("$registration")
-        expect(rack_request).to be_a(Rack::Request)
+        expect(context).to be_a(CastleDevise::Context)
       end
     end
 
@@ -46,9 +46,9 @@ RSpec.describe "Registration attempt", type: :request do
     let(:policy_action) { "challenge" }
 
     it "sends requests to Castle" do
-      expect(facade).to have_received(:filter) do |event:, rack_request:|
+      expect(facade).to have_received(:filter) do |event:, context:|
         expect(event).to eq("$registration")
-        expect(rack_request).to be_a(Rack::Request)
+        expect(context).to be_a(CastleDevise::Context)
       end
     end
 
@@ -59,9 +59,9 @@ RSpec.describe "Registration attempt", type: :request do
     let(:policy_action) { "deny" }
 
     it "sends requests to Castle" do
-      expect(facade).to have_received(:filter) do |event:, rack_request:|
+      expect(facade).to have_received(:filter) do |event:, context:|
         expect(event).to eq("$registration")
-        expect(rack_request).to be_a(Rack::Request)
+        expect(context).to be_a(CastleDevise::Context)
       end
     end
 


### PR DESCRIPTION
This refactoring aims to:

1. Simplify our interfaces a bit:
    - we provide `CastleDevice::Context#request_token` and `CastleDevice#logout!`, so you don't need to know how to exactly do these things with Rack. We will likely pass it as a param to custom error/policy handlers in the future so we can add more
    - drops dependency on activesupport - we now use `rack_request.env["rack.request.form_hash"]["castle_request_token"]`
 
2. Make it easier to support other auth frameworks in the future. Looking at you, Hanami. My thoughts here are that we should still rely on both Warden and Rack as standards, but we might not need `ActiveRecord`. Once a nice Hanami ecosystem emerges, we can do a very simple refactoring: instead of initializing `CastleDevise::Context` with an `ActiveRecord::Base` resource, we can just copy the attributes that are currently delegated, like castle_id, email, user_traits, etc. However, I don't want to over-engineer this now, so I'm not going to include this in this PR scope.