### PR TITLE
release 0.4.2 fix

### DIFF
--- a/lib/castle_devise/version.rb
+++ b/lib/castle_devise/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CastleDevise
-  VERSION = "0.4.2'
+  VERSION = "0.4.2"
 end


### PR DESCRIPTION
Fixing the typo related to `release 0.4.2`.