### PR TITLE
chore: Bump minimum Ruby version to 3.2.0

### DIFF
--- a/castle_devise.gemspec
+++ b/castle_devise.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Integrates Castle with Devise"
   spec.description = "castle_devise provides out-of-the-box protection against bot registrations and account takeover attacks."
   spec.homepage = "https://github.com/castle/castle_devise"
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.2.0")
 
   spec.authors = ["Kacper Madej", "Dawid Libiszewski", "Bartosz Knapik", "Johan Brissmyr"]
   spec.email = ["team@castle.io"]


### PR DESCRIPTION
## Summary

Bumps the minimum required Ruby version for `castle_devise` from `3.0.0` to `3.2.0` in the gemspec.

## Why

Ruby 3.0 and 3.1 have reached end-of-life and no longer receive security updates. Aligning the gem's minimum supported version with currently maintained Ruby releases keeps the supported matrix in line with upstream and ensures users are on a version that still receives security patches.

## Changes

- `castle_devise.gemspec`: `required_ruby_version` updated from `>= 3.0.0` to `>= 3.2.0`.

---

Made with love in Bezrzecze. Sunny, 20°C / 68°F.