### PR TITLE
Bump gems: castle-rb 9.1.0, json 2.19.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   `#risk` / `#filter` / `#log` Client APIs and the `Castle::Error` /
   `InvalidParametersError` / `InvalidRequestTokenError` classes, all of
   which remain in 9.0.
+- Bump `castle-rb` to 9.1.0
 - Add Ruby 3.3, 3.4, and 4.0 to the CI matrix
 - Bump minimum required Ruby version to 3.2
 - Replace deprecated `ActiveSupport::Configurable` with plain Ruby attribute accessors (drops the Rails 8.2 deprecation warning)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/castle/castle-ruby.git
-  revision: 9dce01b248cc10c3e1321c417bd9b5a24aabd5bf
+  revision: 66c0523be56f5f24b8a8933dc522b5487bc77fce
   branch: develop
   specs:
-    castle-rb (9.0.0)
+    castle-rb (9.1.0)
       base64 (~> 0.2)
 
 PATH
@@ -100,7 +100,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.19.5)
+    json (2.19.7)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)


### PR DESCRIPTION
## Summary

Routine dependency update via `bundle update`.

- **castle-rb** 9.0.0 → 9.1.0 (tracks `develop` branch)
- **json** 2.19.5 → 2.19.7

## Test plan

- [ ] CI passes (specs, linting)